### PR TITLE
fix: ellipsis组件由于缺少小数而导致的部分字号(如2.7rem)缺行

### DIFF
--- a/src/components/ellipsis/ellipsis.vue
+++ b/src/components/ellipsis/ellipsis.vue
@@ -157,7 +157,7 @@
                     let height = this.height;
                     // 当 height 未定义，且 lines 定义时，计算真实高度，否则使用 this.height
                     if (!height && this.lines) {
-                        const lineHeight = parseInt(getStyle($el, 'lineHeight'), 10);
+                        const lineHeight = parseFloat(getStyle($el, 'lineHeight'), 10);
                         height = lineHeight * this.lines;
                     }
 


### PR DESCRIPTION
解决以下issue中提到的漏洞
[[Bug Report]ellipsis设置lines显示错误](https://github.com/view-design/ViewUIPlus/issues/208)
### 归因
经简单测试得出这是由于**粗暴地取整**导致；
如在我的电脑上lineHeight=2.7rem=64.8px，被取作64，
此时导致计算出的height略小于实际需要的高度，导致行数>1时总是缺少1行。

测试使用来自上述issue的代码