### PR TITLE
树组件样式调整: 箭头间距补充

### DIFF
--- a/src/styles/components/tree.less
+++ b/src/styles/components/tree.less
@@ -32,7 +32,7 @@
     }
     &-title {
         display: inline-block;
-        margin: 0;
+        margin: 0 4px;
         padding: 0 4px;
         border-radius: @btn-border-radius-small;
         cursor: pointer;


### PR DESCRIPTION
进行以下issue中提出的样式修改
[[Feature Request\]树组件箭头样式间距未继承原版本](https://github.com/view-design/ViewUIPlus/issues/211)

[问题复现](https://run.iviewui.com/HH8NzDu7)

修改后可以有效防止用户在展开和选择之间误触