### PR TITLE
Fix: 禁用的树节点不被父节点影响

### DIFF
--- a/src/components/ellipsis/ellipsis.vue
+++ b/src/components/ellipsis/ellipsis.vue
@@ -157,7 +157,7 @@
                     let height = this.height;
                     // 当 height 未定义，且 lines 定义时，计算真实高度，否则使用 this.height
                     if (!height && this.lines) {
-                        const lineHeight = parseInt(getStyle($el, 'lineHeight'), 10);
+                        const lineHeight = parseFloat(getStyle($el, 'lineHeight'), 10);
                         height = lineHeight * this.lines;
                     }
 

--- a/src/components/tree/tree.vue
+++ b/src/components/tree/tree.vue
@@ -194,7 +194,10 @@
                 }
                 if (node[this.childrenKey]) {
                     node[this.childrenKey].forEach(child => {
-                        this.updateTreeDown(child, changes);
+                        if(child.disabled)
+                            this.updateTreeDown(child, {checked: false, indeterminate: false});
+                        else
+                            this.updateTreeDown(child, changes);
                     });
                 }
             },


### PR DESCRIPTION
**当前的版本**
虽然子节点被禁用，但可以通过父节点选中被禁用的子节点
disabled和disableCheckbox两个属性仅有的区别为
- disabled禁用了响应函数
- disabled会设置额外的样式(Classes)，但是似乎这些样式是空的

**修改后**
disabled的节点无法被父节点选中
> 目前存在的问题：  
> 没有处理子节点，因此可以通过子节点选中disabled的父节点  
> 可能的方案：考虑到实际使用，可以将disabled节点显示为叶子节点，无法展开  
> 或者 将disabled节点的子节点全部设置为disabled的

## Tree 树形控件
### API
#### Children
属性 | 说明 | 类型 | 默认值
-- | -- | -- | --
disabled | 禁用checkbox和响应，不能被父节点选中 | Boolean | false
disableCheckbox | 禁掉 checkbox | Boolean | false