### PR TITLE
fix: Modal组件可拖拽状态下设置宽度为百分比时窗口显示异常

### DIFF
--- a/src/components/modal/modal.vue
+++ b/src/components/modal/modal.vue
@@ -247,7 +247,10 @@
                     const styleWidth = {
                         width: width <= 100 ? `${width}%` : `${width}px`
                     };
-
+                    if(this.dragData.x == null){
+                        styleWidth.width=`100%`;
+                    }
+                    
                     Object.assign(style, styleWidth);
                 }
 


### PR DESCRIPTION
对以下issue中提出的bug进行修复
[[Bug Report\]Modal组件 可拖拽状态下 设置宽度为百分比时窗口显示异常](https://github.com/view-design/ViewUIPlus/issues/208)

[问题复现](https://run.iviewui.com/kK1PABKL)

bug原因
Modal组件在可拖拽状态下，初始化时重复设置了Width属性，因此当宽度设置为固定值时没有错误，而设置为百分比时会将两个百分比相乘作为最终结果
而在窗口位置发生移动时，会将整体宽度设置为100%，此时表现正常

解决方法
由于需要初始化窗口位置，所以保留初始化时对整体宽度的设置，去除窗口宽度设置
在后续窗口位置发生移动时，在将整体宽度设置为100%时同时为窗口补充宽度设置