### PR TITLE
带有展开项的表格，‘全选’ 导致异常 Uncaught RangeError: Invalid array length

### DIFF
--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -812,7 +812,7 @@
                     const objData = this.objData[i];
                     if (objData._isChecked) selectionIndexes.push(parseInt(i));
                     if (objData.children && objData.children.length) {
-                        selectionRowKeys = selectionRowKeys.concat(this.getSelectionChildrenRowKeys(objData, selectionRowKeys));
+                        selectionRowKeys = selectionRowKeys.concat(this.getSelectionChildrenRowKeys(objData));
                     }
                 }
 
@@ -826,7 +826,7 @@
                         selection = selection.concat(item);
                     }
                     if (item.children && item.children.length && selectionRowKeys.length) {
-                        selection = selection.concat(this.getSelectionChildren(item, selection, selectionRowKeys));
+                        selection = selection.concat(this.getSelectionChildren(item, selectionRowKeys));
                     }
                 });
 
@@ -834,25 +834,27 @@
                 selection = [...new Set(selection)];
                 return JSON.parse(JSON.stringify(selection));
             },
-            getSelectionChildrenRowKeys (objData, selectionRowKeys) {
+            getSelectionChildrenRowKeys (objData) {
+                let selectionRowKeys = [];
                 if (objData.children && objData.children.length) {
                     objData.children.forEach(item => {
                         if (item._isChecked) selectionRowKeys.push(item._rowKey);
                         if (item.children && item.children.length) {
-                            selectionRowKeys = selectionRowKeys.concat(this.getSelectionChildrenRowKeys(item, selectionRowKeys));
+                            selectionRowKeys = selectionRowKeys.concat(this.getSelectionChildrenRowKeys(item));
                         }
                     });
                 }
                 return selectionRowKeys;
             },
-            getSelectionChildren (data, selection, selectionRowKeys) {
+            getSelectionChildren (data, selectionRowKeys) {
+                let selection = [];
                 if (data.children && data.children.length) {
                     data.children.forEach(item => {
                         if (selectionRowKeys.indexOf(item[this.rowKey]) > -1) {
                             selection = selection.concat(item);
                         }
                         if (item.children && item.children.length) {
-                            selection = selection.concat(this.getSelectionChildren(item, selection, selectionRowKeys));
+                            selection = selection.concat(this.getSelectionChildren(item, selectionRowKeys));
                         }
                     });
                 }


### PR DESCRIPTION
<!-- 请提交 PR 到 master 分支 | Please send PR to master branch -->
<!-- 如果试图解决一个问题，请附上能够最小化复现问题的 run.iviewui.com 链接 -->

table 的 getSelection() 及其子函数，对 selectionRowKeys 和 selection 数组进行反复叠加自身，导致这两个数组过长

修复子函数的递归操作

![61db7e23e75d41fc420f862fd1b0bb2](https://user-images.githubusercontent.com/9971413/224971487-6e5ed06c-40ce-486d-a0ae-6e84dd48d1f4.png)

![0714c42b6ad02e8e39af6ccfe8cb09e](https://user-images.githubusercontent.com/9971413/224971541-579086d8-32a4-4a03-b51b-de674fb27f99.png)

<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
