### PR TITLE
fix: #227 修复1.3.10版本select组件filterable时，改变文字未过滤的问题。

### DIFF
--- a/src/components/select/option.vue
+++ b/src/components/select/option.vue
@@ -101,17 +101,14 @@
                 const filterByLabel = SelectInstance.filterByLabel;
                 const slotOptionsMap = SelectInstance.slotOptionsMap;
                 const { props } = slotOptionsMap.get(this.value) || { props: {} };
-                const label = this.label || this.$el && this.$el.textContent;
-                let showAllFilterOption = false;                
+                const label = this.label || this.$el && this.$el.textContent;           
                 let filterOption = (label || props.value || '').toLowerCase();
                 if (filterByLabel) {
                     filterOption = (label || '').toLowerCase();
                 }
-                if (filterable) {
-                    showAllFilterOption= SelectInstance.slotOptionsMap.has(this.value);
-                }
                 const showFilterOption = filterOption.includes(query);
-                return !filterable || filterable && (showFilterOption || showAllFilterOption) || typeOf(SelectInstance.remoteMethod) === 'function';
+                return !filterable || !SelectInstance.filterQueryChange
+                    || showFilterOption || typeOf(SelectInstance.remoteMethod) === 'function';
             },
             selected(){
                 const SelectInstance = this.SelectInstance;


### PR DESCRIPTION
#227 vue3版本的代码跟vue2版本的代码这个显示逻辑变了，因为vue3版本少了SelectInstance.filterQueryChange这个状态的判断，才导致选中了之后，再打开下拉框，下拉框会直接过滤，目前改的选中之后是不会过滤了，但是改变query值它也不过滤了，建议在1.3.1版本的逻辑上面增加 !SelectInstance.filterQueryChange 判断。

