### PR TITLE
fix: fix FormItem required status error

### DIFF
--- a/src/components/form/form-item.vue
+++ b/src/components/form/form-item.vue
@@ -162,9 +162,7 @@
                 if (rules.length && this.required) {
                     return;
                 } else if (rules.length) {
-                    rules.every((rule) => {
-                        this.isRequired = rule.required;
-                    });
+                    this.isRequired = rules.some((rule) => rule.required)
                 } else if (this.required) {
                     this.isRequired = this.required;
                 }


### PR DESCRIPTION
当FormItem表单项的校验规则为：
[
      {
        validator: (rule, value, callback) => { 
        	callback()
      	}, 
        trigger: 'blur'
      },
      { required: true, message: 'Please fill in the user name', trigger: 'blur' }
]时，label前方的红*会丢失。复现见：https://run.iviewui.com/zw7u2Wri