### PR TITLE
Support tree-shaking

### DIFF
--- a/build/vite.esm.config.js
+++ b/build/vite.esm.config.js
@@ -1,0 +1,37 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import path from 'path';
+
+const config = defineConfig({
+    plugins: [vue()],
+    target: 'es2015',
+    build: {
+        outDir: path.resolve(__dirname, '../dist/esm'),
+        emptyOutDir: true,
+        cssCodeSplit: true,
+        minify: false,
+        rollupOptions: {
+            context: 'globalThis',
+            preserveEntrySignatures: 'strict',
+            input: path.resolve(__dirname, '../src/index.js'),
+            external: (id) => {
+                return !/^(src|\.|\/|plugin-vue:export-helper)/.test(id)
+            },
+            output: [
+                {
+                    format: "esm",
+                    preserveModules: true,
+                    preserveModulesRoot: "src",
+                    entryFileNames: () => {
+                        return '[name].js';
+                    }
+                },
+            ],
+        },
+    },
+    resolve: {
+        extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json', '.vue']
+    }
+});
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,15 @@
         "framework"
     ],
     "main": "dist/viewuiplus.min.js",
+    "exports": {
+        ".": {
+            "types": "./types/index.d.ts",
+            "import": "./dist/esm/index.js",
+            "require": "./dist/viewuiplus.min.js"
+        },
+        "./*": "./*.js",
+        "./*.json": "./*.json"
+    },
     "typings": "types/index.d.ts",
     "files": [
         "dist",
@@ -24,10 +33,11 @@
     ],
     "scripts": {
         "dev": "vue-cli-service serve",
-        "build": "npm run build:prod && npm run build:style && npm run build:lang",
+        "build": "npm run build:prod && npm run build:esm && npm run build:style && npm run build:lang",
         "build:style": "gulp --gulpfile build/build-style.js",
         "build:prod": "vite build",
         "build:lang": "vite build --config build/vite.lang.config.js",
+        "build:esm": "vite build --config build/vite.esm.config.js",
         "lint": "vue-cli-service lint --fix"
     },
     "repository": {


### PR DESCRIPTION
These improvements allow to build preserved ES modules instead of merging them into single bundle, which is why tree-shaking feature wasn't possible

The package with tre-shaking: https://www.npmjs.com/package/view-ui-plus-es