### PR TITLE
fix: Table component, handleMouseWheel 方法中deltaX取值错误，始终为-0，导致表头使用滑轮横向…

### DIFF
--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -1140,7 +1140,7 @@
                 }, 5);
             },
             handleMouseWheel (event) {
-                const deltaX = event.deltaX;
+                const deltaX = event.wheelDelta;
                 const $body = this.$refs.body;
 
                 if (deltaX > 0) {


### PR DESCRIPTION
fix: Table component, handleMouseWheel 方法中deltaX取值错误，始终为-0，导致表头使用滑轮横向滚动方向一直为向左滚动，需要更改取值event.deltaX为event.wheelDelta才可以正常滚动

<!-- 请提交 PR 到 master 分支 | Please send PR to master branch -->
<!-- 如果试图解决一个问题，请附上能够最小化复现问题的 run.iviewui.com 链接 -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
