### PR TITLE
Fix #412

### DIFF
--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -53,7 +53,7 @@
                     <table-head
                         fixed="left"
                         :prefix-cls="prefixCls"
-                        :styleObject="fixedTableStyle"
+                        :styleObject="tableStyle"
                         :columns="leftFixedColumns"
                         :column-rows="columnRows"
                         :fixed-column-rows="leftFixedColumnRows"
@@ -66,7 +66,7 @@
                         fixed="left"
                         :draggable="draggable"
                         :prefix-cls="prefixCls"
-                        :styleObject="fixedTableStyle"
+                        :styleObject="tableStyle"
                         :columns="leftFixedColumns"
                         :data="rebuildData"
                         :row-key="rowKey"
@@ -77,14 +77,14 @@
                     v-if="showSummary && (data && data.length)"
                     fixed="left"
                     :prefix-cls="prefixCls"
-                    :styleObject="fixedTableStyle"
+                    :styleObject="tableStyle"
                     :columns="leftFixedColumns"
                     :data="summaryData"
                     :columns-width="columnsWidth"
                     :style="{ 'margin-top': showHorizontalScrollBar ? scrollBarWidth + 'px' : 0 }"
                 />
             </div>
-            <div :class="fixedRightTableClasses" :style="fixedRightTableStyle" v-if="isRightFixed">
+            <div :class="fixedRightTableClasses" :style="fixedRightStyle" v-if="isRightFixed">
                 <div :class="fixedHeaderClasses" v-if="showHeader">
                     <table-head
                         fixed="right"
@@ -481,7 +481,7 @@
                 style.width = `${width}px`;
                 return style;
             },
-            fixedRightTableStyle () {
+            fixedRightStyle () {
                 let style = {};
                 let width = 0;
                 this.rightFixedColumns.forEach((col) => {
@@ -489,6 +489,20 @@
                 });
                 //width += this.scrollBarWidth;
                 style.width = `${width}px`;
+                style.right = `${this.showVerticalScrollBar?this.scrollBarWidth:0}px`;
+                return style;
+            },
+            fixedRightTableStyle () {
+                let style = {}
+                if (this.tableWidth !== 0) {
+                    let width = '';
+                    if (this.bodyHeight === 0) {
+                        width = this.tableWidth;
+                    } else {
+                        width = this.tableWidth - (this.showVerticalScrollBar?this.scrollBarWidth:0);
+                    }
+                    style.width = `${width}px`;
+                }
                 style.right = `${this.showVerticalScrollBar?this.scrollBarWidth:0}px`;
                 return style;
             },


### PR DESCRIPTION
修复Table组件在使用 fixed 时导致错位的问题，问题来自https://github.com/view-design/ViewUIPlus/issues/412
原因分析：
当表格设置了整体宽度时，固定列对应的 `<table>` 实际宽度只等于固定列自身的宽度。
浏览器在渲染时会根据列宽自动计算行高，但由于 fixed 列的 `<table>` 宽度不足，内容可能 被截断或换行错误。
结果导致固定列显示的文字行数与主体表格不一致，从而产生错位。
解决方案：
将固定列 `<table>` 的宽度设置为 与主体表格相同。
这样浏览器在计算列宽和换行时，固定列与主体列保持一致，从而避免错位问题。